### PR TITLE
Switch to Alpine Base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM debian:stable-slim
+FROM alpine:3.7
 LABEL maintainer="Andrew Huynh <a5thuynh@gmail.com>"
 
 # When this Dockerfile was last refreshed (year/month/day)
-ENV REFRESHED_AT 2017-10-24
+ENV REFRESHED_AT 2018-04-11
 ENV OAUTH2_PROXY_VERSION 2.2
 
 # Checkout bitly's latest google-auth-proxy code from Github
@@ -10,7 +10,7 @@ ADD https://github.com/bitly/oauth2_proxy/releases/download/v2.2/oauth2_proxy-2.
 RUN tar -xf /tmp/oauth2_proxy-2.2.0.linux-amd64.go1.8.1.tar.gz -C ./bin --strip-components=1 && rm /tmp/*.tar.gz
 
 # Install CA certificates
-RUN apt-get update -y && apt-get install -y ca-certificates
+RUN apk add --no-cache --virtual=build-dependencies ca-certificates
 
 # Expose the ports we need and setup the ENTRYPOINT w/ the default argument
 # to be pass in.


### PR DESCRIPTION
This commit switches the docker image to an alpine base, which results
in a much smaller image. (18.5 MB vs 91.8 MB)